### PR TITLE
Condense enclosures

### DIFF
--- a/src/public/Format-ScriptCondenseEnclosures.ps1
+++ b/src/public/Format-ScriptCondenseEnclosures.ps1
@@ -53,26 +53,25 @@
         $Output = @()
         $Count = 0
         $LineCount = 0
+        $codeLine = 0
+        $codeColumn = 0
     }
     process {
         $Codeblock += $Code
     }
     end {
        $ScriptText = ($Codeblock | Out-String).trim([System.Environment]::NewLine)
-        try
-        {
+        try {
             $KindLines = @($ScriptText | Format-ScriptGetKindLines -Kind "HereString*")
             $KindLines += @($ScriptText | Format-ScriptGetKindLines  -Kind 'Comment')
         }
-        catch
-        {
+        catch {
             throw "$($FunctionName): Unable to properly parse the code for herestrings/comments..."
         }
         ($Codeblock -split [System.Environment]::NewLine)  | Foreach {
             $LineCount++
             
-            if (($_ -match $regex) -and ($Count -gt 0))
-            {
+            if (($_ -match $regex) -and ($Count -gt 0)) {
                 $encfound = $Matches[1]
                 Write-Verbose "$($FunctionName): Condensed enclosure $($encfound) at line $LineCount"
 
@@ -84,8 +83,7 @@
                     $Output[$codeLine] = $Output[$codeLine].Insert($Output[$codeLine].Length,$encfound)
                 }
             }
-            else
-            {
+            else {
                 $tokens=[System.Management.Automation.PSParser]::Tokenize($_,[ref]$null)
 
                 # Get line and column to put enclosure in

--- a/test/Pester/Data/testcase-condenseenclosures.ps1
+++ b/test/Pester/Data/testcase-condenseenclosures.ps1
@@ -1,0 +1,20 @@
+#comment string
+"Code string"
+if($true) #comment
+
+
+
+
+
+{
+	"True"
+}
+
+$array = 
+<# array entries #>
+
+
+@(
+"Test1",
+"TEst2"
+)

--- a/test/Pester/Data/testcase-condenseenclosures.ps1
+++ b/test/Pester/Data/testcase-condenseenclosures.ps1
@@ -1,20 +1,35 @@
 #comment string
 "Code string"
-if($true) #comment
+if($true){ #comment
 
 
+
+
+
+	"True"
+}
+
+$array =#here is comment string
+<# array entries #>
+
+@(
+
+"Test1",
+"TEst2"
+)
+function Test
 
 
 
 {
-	"True"
+
+
+$a=
+
+(
+"Working"
+)
+$a
 }
 
-$array = 
-<# array entries #>
-
-
-@(
-"Test1",
-"TEst2"
-)
+Test

--- a/test/Pester/Data/testcase-condenseenclosures.ps1
+++ b/test/Pester/Data/testcase-condenseenclosures.ps1
@@ -1,7 +1,7 @@
 #comment string
 "Code string"
-if($true){ #comment
-
+if($true) #comment
+{
 
 
 


### PR DESCRIPTION
1. Original function will not put an enclosure at the end of code line if there are multiple newlines. It just moves it higher. The function was changed to put enclosure exactly at the end of last line with code. 

2. Original function puts enclosure after comment line but I think it is better to leave comment line after enclosure.


For example:
![image](https://cloud.githubusercontent.com/assets/21568021/20860677/ad439418-b98e-11e6-841b-599e64b3223d.png)

Will be converted into:
![image](https://cloud.githubusercontent.com/assets/21568021/20860654/2d325c64-b98e-11e6-8c2d-1b8e8658c19e.png)
