### PR TITLE
Code indentation

### DIFF
--- a/src/public/Format-ScriptFormatCodeIndentation.ps1
+++ b/src/public/Format-ScriptFormatCodeIndentation.ps1
@@ -74,7 +74,7 @@
             $Token = $Tokens[$t]
             $NextToken = $Tokens[$t-1]
 
-            if ($token.Kind -match '(L|At)(Curly|Paren|Bracket)' ) { 
+            if ($token.Kind -match '(L|At)(Curly|Paren|Bracket)') { 
                 $CurrentLevel-- 
             }  
 

--- a/src/public/Format-ScriptFormatCodeIndentation.ps1
+++ b/src/public/Format-ScriptFormatCodeIndentation.ps1
@@ -74,7 +74,7 @@
             $Token = $Tokens[$t]
             $NextToken = $Tokens[$t-1]
 
-            if ($token.Kind -match '(L|At)(Curly|Paren|Bracket)') { 
+            if ($token.Kind -match '(L|At)(Curly|Paren|Bracket)' ) { 
                 $CurrentLevel-- 
             }  
 

--- a/src/public/Format-ScriptFormatCodeIndentation.ps1
+++ b/src/public/Format-ScriptFormatCodeIndentation.ps1
@@ -74,7 +74,7 @@
             $Token = $Tokens[$t]
             $NextToken = $Tokens[$t-1]
 
-            if ($token.Kind -match '(L|At)Curly') { 
+            if ($token.Kind -match '(L|At)(Curly|Paren|Bracket)') { 
                 $CurrentLevel-- 
             }  
 
@@ -86,7 +86,7 @@
                 $ScriptText = $ScriptText.Remove($RemoveStart,$RemoveEnd).Insert($RemoveStart,$IndentText)
             }
 
-            if ($token.Kind -eq 'RCurly') {
+            if ($token.Kind -match 'R(Curly|Paren|Bracket)') {
                 $CurrentLevel++ 
             }
         }

--- a/src/public/Format-ScriptFormatCodeIndentation.ps1
+++ b/src/public/Format-ScriptFormatCodeIndentation.ps1
@@ -86,7 +86,7 @@
                 $ScriptText = $ScriptText.Remove($RemoveStart,$RemoveEnd).Insert($RemoveStart,$IndentText)
             }
 
-            if ($token.Kind -eq 'R(Curly|Paren|Bracket)') {
+            if ($token.Kind -match 'R(Curly|Paren|Bracket)') {
                 $CurrentLevel++ 
             }
         }

--- a/src/public/Format-ScriptFormatCodeIndentation.ps1
+++ b/src/public/Format-ScriptFormatCodeIndentation.ps1
@@ -74,7 +74,7 @@
             $Token = $Tokens[$t]
             $NextToken = $Tokens[$t-1]
 
-            if ($token.Kind -match '(L|At)(Curly|Paren|Bracket)') { 
+            if ($token.Kind -match '^(Dollar|L|At)(Curly|Paren|Bracket)$') { 
                 $CurrentLevel-- 
             }  
 
@@ -86,7 +86,7 @@
                 $ScriptText = $ScriptText.Remove($RemoveStart,$RemoveEnd).Insert($RemoveStart,$IndentText)
             }
 
-            if ($token.Kind -match 'R(Curly|Paren|Bracket)') {
+            if ($token.Kind -match '^R(Curly|Paren|Bracket)$') {
                 $CurrentLevel++ 
             }
         }

--- a/src/public/Format-ScriptFormatCodeIndentation.ps1
+++ b/src/public/Format-ScriptFormatCodeIndentation.ps1
@@ -74,7 +74,7 @@
             $Token = $Tokens[$t]
             $NextToken = $Tokens[$t-1]
 
-            if ($token.Kind -match '(L|At)Curly') { 
+            if ($token.Kind -match '(L|At)(Curly|Paren|Bracket)') { 
                 $CurrentLevel-- 
             }  
 
@@ -86,7 +86,7 @@
                 $ScriptText = $ScriptText.Remove($RemoveStart,$RemoveEnd).Insert($RemoveStart,$IndentText)
             }
 
-            if ($token.Kind -eq 'RCurly') {
+            if ($token.Kind -eq 'R(Curly|Paren|Bracket)') {
                 $CurrentLevel++ 
             }
         }

--- a/src/public/Format-ScriptFormatCodeIndentation.ps1
+++ b/src/public/Format-ScriptFormatCodeIndentation.ps1
@@ -74,7 +74,7 @@
             $Token = $Tokens[$t]
             $NextToken = $Tokens[$t-1]
 
-            if ($token.Kind -match '(L|At)(Curly|Paren|Bracket)') { 
+            if ($token.Kind -match '(L|At)Curly') { 
                 $CurrentLevel-- 
             }  
 
@@ -86,7 +86,7 @@
                 $ScriptText = $ScriptText.Remove($RemoveStart,$RemoveEnd).Insert($RemoveStart,$IndentText)
             }
 
-            if ($token.Kind -match 'R(Curly|Paren|Bracket)') {
+            if ($token.Kind -eq 'RCurly') {
                 $CurrentLevel++ 
             }
         }


### PR DESCRIPTION
Added code indentation for other types of enclosures, like @(), $(), (), []. It should make code easier for reading. 
For example the following flat code:
```powershell
function Test{
param(
[parameter(Position = 0, 
Mandatory = $false, 
ValueFromPipeline=$true)]
[string]
$Path
)

#array
$a=@( 'this is first string',
'this is second string',
'this is third string'
)

#hash array
$h=@{ 'First' = 'String1'
'Second' = 'String2'
'Third' = 'String3'
}

#script block
$s={
"Hi there"
}

#Expression
$e=$("Here is some"
"expression"
)
}
```

Original formatting:
```powershell
function Test{
    param(
    [parameter(Position = 0, 
    Mandatory = $false, 
    ValueFromPipeline=$true)]
    [string]
    $Path
    )
    
    #array
    $a=@( 'this is first string',
    'this is second string',
    'this is third string'
    )
    
    #hash array
    $h=@{ 'First' = 'String1'
        'Second' = 'String2'
        'Third' = 'String3'
    }
    
    #script block
    $s={
        "Hi there"
    }
    
    #Expression
    $e=$("Here is some"
    "expression"
    )
}
```
Param block, expression and array is still flat

Modified formatting:
```powershell
function Test{
    param(
        [parameter(Position = 0, 
                Mandatory = $false, 
                ValueFromPipeline=$true)]
        [string]
        $Path
    )
    
    #array
    $a=@( 'this is first string',
        'this is second string',
        'this is third string'
    )
    
    #hash array
    $h=@{ 'First' = 'String1'
        'Second' = 'String2'
        'Third' = 'String3'
    }
    
    #script block
    $s={
        "Hi there"
    }
    
    #Expression
    $e=$("Here is some"
        "expression"
    )
}
```

Param block, expression and arrays are different. It looks like more natural formatting. 