### PR TITLE
Added $PSScriptRoot to .psm1 file and exclusion for [ordered] in for format type names

### DIFF
--- a/FormatPowershellCode.psm1
+++ b/FormatPowershellCode.psm1
@@ -1,13 +1,13 @@
 ﻿# This psm1 file is purely for development. The build script will recreate this file entirely.
 
 # Private and other methods and variables
-Get-ChildItem '.\src\private','.\src\other' -Recurse -Filter "*.ps1" -File | Sort-Object Name | Foreach { 
+Get-ChildItem "$PSScriptRoot\src\private","$PSScriptRoot\src\other" -Recurse -Filter "*.ps1" -File | Sort-Object Name | Foreach { 
     Write-Verbose "Dot sourcing private script file: $($_.Name)"
     . $_.FullName
 }
 
 # Load and export public methods
-Get-ChildItem '.\src\public' -Recurse -Filter "*.ps1" -File | Sort-Object Name | Foreach { 
+Get-ChildItem "$PSScriptRoot\src\public" -Recurse -Filter "*.ps1" -File | Sort-Object Name | Foreach { 
     Write-Verbose "Dot sourcing public script file: $($_.Name)"
     . $_.FullName
 

--- a/src/public/Format-ScriptFormatTypeNames.ps1
+++ b/src/public/Format-ScriptFormatTypeNames.ps1
@@ -66,11 +66,10 @@
             ($args[0] -is [System.Management.Automation.Language.TypeExpressionAst]) -or 
             ($args[0] -is [System.Management.Automation.Language.TypeConstraintAst])
         }
-        $types = $ast.FindAll($predicate, $true)
+        $types = $ast.FindAll($predicate, $true) | Where-Object { $_.TypeName.Name -ne 'ordered' }
 
         for($t = $types.Count - 1; $t -ge 0; $t--) {
             $type = $types[$t]
-            
             $typeName = $type.TypeName.Name
             $extent = $type.TypeName.Extent
     		$FullTypeName = Invoke-Expression "$type"


### PR DESCRIPTION
1. When importing the module downloaded from the PowerShell Gallery I received an error message pointing to the .psm1 file, therefore I replaced the root folder references (.\) with $PSScriptRoot

2. [ordered] appears not be a type accelerator [stackoverflow post](https://stackoverflow.com/questions/10238698/what-is-the-proper-name-for-what-ordered-is-in-powershell-3-0). I've added an exclusion into the Format-ScriptFormatTypeNames.ps1.

Thanks a lot for the great module,

Dirk